### PR TITLE
Deps/bump jimp 0.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ gulp.task('default', function () {
 
 #### Options
 
-Support all Jimp functionalities as of version 0.1.1.
+Support all Jimp functionalities as of version 0.2.9.
 
 You can define the transformations in the options, and add as many as you want (see example above).
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "homepage": "https://github.com/antoinejaussoin/gulp-jimp",
     "dependencies": {
         "event-stream": "^3.1.7",
-        "jimp": "^0.1.1"
+        "jimp": "^0.2.9"
     },
     "devDependencies": {
         "mocha": "^2.0.1",


### PR DESCRIPTION
gulp-jimp is using old jimp version. just bumped it
